### PR TITLE
Block SSRF via unrestricted webhook endpoint URLs

### DIFF
--- a/app/Http/Controllers/Api/EndpointController.php
+++ b/app/Http/Controllers/Api/EndpointController.php
@@ -4,8 +4,9 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Endpoint;
-use Illuminate\Http\Request;
+use App\Rules\SafeWebhookUrl;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
@@ -30,7 +31,7 @@ class EndpointController extends Controller
     {
         $validator = Validator::make($request->all(), [
             'name' => 'required|string|max:255',
-            'url' => 'required|url|max:2048',
+            'url' => ['required', 'url', 'max:2048', new SafeWebhookUrl],
             'description' => 'nullable|string|max:1000',
             'is_active' => 'boolean',
         ]);
@@ -77,7 +78,7 @@ class EndpointController extends Controller
 
         $validator = Validator::make($request->all(), [
             'name' => 'string|max:255',
-            'url' => 'url|max:2048',
+            'url' => ['url', 'max:2048', new SafeWebhookUrl],
             'description' => 'nullable|string|max:1000',
             'is_active' => 'boolean',
         ]);

--- a/app/Jobs/SendWebhook.php
+++ b/app/Jobs/SendWebhook.php
@@ -3,7 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Delivery;
-use App\Models\Endpoint;
+use App\Rules\SafeWebhookUrl;
 use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -42,8 +42,27 @@ class SendWebhook implements ShouldQueue
 
         $endpoint = $this->delivery->endpoint;
 
-        if (!$endpoint || $endpoint->trashed()) {
+        if (! $endpoint || $endpoint->trashed()) {
             $this->delivery->update(['status' => 'failed', 'response_body' => 'Endpoint was deleted.']);
+
+            return;
+        }
+
+        if (! SafeWebhookUrl::isUrlSafe($endpoint->url)) {
+            Log::warning('Webhook delivery blocked: endpoint URL resolves to a disallowed network address', [
+                'delivery_id' => $this->delivery->id,
+                'endpoint_url' => $endpoint->url,
+            ]);
+
+            $this->delivery->update([
+                'status' => 'failed',
+                'response_code' => null,
+                'response_body' => 'Delivery blocked: endpoint URL resolves to a private, loopback, or reserved network address.',
+                'delivered_at' => null,
+            ]);
+
+            $this->handleFailedDelivery();
+
             return;
         }
 
@@ -52,6 +71,7 @@ class SendWebhook implements ShouldQueue
         try {
             $start = microtime(true);
             $response = Http::timeout(30)
+                ->withOptions(['allow_redirects' => false])
                 ->withHeaders([
                     'Content-Type' => 'application/json',
                     'X-Webhook-Secret' => hash_hmac('sha256', json_encode($payload), $endpoint->secret_key),

--- a/app/Rules/SafeWebhookUrl.php
+++ b/app/Rules/SafeWebhookUrl.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Rejects webhook endpoint URLs that would cause the server to make
+ * outbound requests to loopback, link-local, private, or otherwise
+ * reserved network addresses (SSRF prevention).
+ */
+class SafeWebhookUrl implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || ! self::isUrlSafe($value)) {
+            $fail('The :attribute must be a publicly routable HTTP or HTTPS URL.');
+        }
+    }
+
+    /**
+     * Determine whether a URL's scheme is HTTP(S) and its host resolves
+     * only to publicly routable IP addresses.
+     */
+    public static function isUrlSafe(string $url): bool
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower($parts['scheme'] ?? '');
+        $host = $parts['host'] ?? null;
+
+        if (! in_array($scheme, ['http', 'https'], true) || ! $host) {
+            return false;
+        }
+
+        return self::isHostSafe($host);
+    }
+
+    /**
+     * Determine whether every IP address a host resolves to is publicly
+     * routable (i.e. not loopback, link-local, private, or reserved).
+     */
+    public static function isHostSafe(string $host): bool
+    {
+        $host = trim($host, '[]');
+        $ips = filter_var($host, FILTER_VALIDATE_IP) ? [$host] : self::resolveHost($host);
+
+        if (empty($ips)) {
+            return false;
+        }
+
+        foreach ($ips as $ip) {
+            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function resolveHost(string $host): array
+    {
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+
+        if ($records === false) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (array $record) => $record['ip'] ?? $record['ipv6'] ?? null,
+            $records
+        )));
+    }
+}

--- a/tests/Feature/EndpointSsrfProtectionTest.php
+++ b/tests/Feature/EndpointSsrfProtectionTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Endpoint;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EndpointSsrfProtectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_endpoint_with_loopback_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/v1/endpoints', [
+            'name' => 'Malicious Endpoint',
+            'url' => 'http://127.0.0.1/steal-data',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('url');
+        $this->assertDatabaseCount('endpoints', 0);
+    }
+
+    public function test_creating_endpoint_with_cloud_metadata_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/v1/endpoints', [
+            'name' => 'Metadata Endpoint',
+            'url' => 'http://169.254.169.254/latest/meta-data/',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('url');
+    }
+
+    public function test_creating_endpoint_with_private_network_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/v1/endpoints', [
+            'name' => 'Internal Endpoint',
+            'url' => 'http://10.0.0.5/internal-api',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('url');
+    }
+
+    public function test_creating_endpoint_with_public_ip_url_is_allowed(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/v1/endpoints', [
+            'name' => 'Public Endpoint',
+            'url' => 'http://8.8.8.8/webhook',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('endpoints', ['url' => 'http://8.8.8.8/webhook']);
+    }
+
+    public function test_updating_endpoint_to_loopback_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $endpoint = Endpoint::factory()->for($user)->create();
+
+        $response = $this->actingAs($user)->putJson("/api/v1/endpoints/{$endpoint->id}", [
+            'url' => 'http://127.0.0.1/steal-data',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors('url');
+        $this->assertDatabaseHas('endpoints', ['id' => $endpoint->id, 'url' => $endpoint->url]);
+    }
+}

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -8,12 +8,12 @@ use Tests\TestCase;
 class ExampleTest extends TestCase
 {
     /**
-     * A basic test example.
+     * The root URL redirects to the dashboard.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_the_application_redirects_to_the_dashboard(): void
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertRedirect(route('dashboard'));
     }
 }

--- a/tests/Feature/SendWebhookSsrfProtectionTest.php
+++ b/tests/Feature/SendWebhookSsrfProtectionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Jobs\SendWebhook;
+use App\Models\Delivery;
+use App\Models\Endpoint;
+use App\Models\Event;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class SendWebhookSsrfProtectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_delivery_to_unsafe_url_is_blocked_without_making_a_request(): void
+    {
+        Http::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $event = Event::factory()->for($user)->create();
+
+        // Bypasses controller validation to simulate a DNS-rebinding scenario
+        // where the endpoint URL resolved safely at creation time but not now.
+        $endpoint = Endpoint::factory()->for($user)->create([
+            'url' => 'http://169.254.169.254/latest/meta-data/',
+        ]);
+
+        $delivery = Delivery::factory()->create([
+            'event_id' => $event->id,
+            'endpoint_id' => $endpoint->id,
+            'status' => 'pending',
+            'attempt_count' => 0,
+            'next_retry_at' => null,
+        ]);
+
+        (new SendWebhook($delivery))->handle();
+
+        Http::assertNothingSent();
+
+        $delivery->refresh();
+        $this->assertSame('failed', $delivery->status);
+        $this->assertStringContainsString('blocked', strtolower($delivery->response_body));
+        $this->assertNotNull($delivery->next_retry_at);
+    }
+
+    public function test_delivery_to_safe_url_still_makes_a_request(): void
+    {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $event = Event::factory()->for($user)->create();
+        $endpoint = Endpoint::factory()->for($user)->create(['url' => 'http://8.8.8.8/webhook']);
+
+        $delivery = Delivery::factory()->create([
+            'event_id' => $event->id,
+            'endpoint_id' => $endpoint->id,
+            'status' => 'pending',
+            'attempt_count' => 0,
+            'next_retry_at' => null,
+        ]);
+
+        (new SendWebhook($delivery))->handle();
+
+        Http::assertSent(fn ($request) => $request->url() === 'http://8.8.8.8/webhook');
+
+        $delivery->refresh();
+        $this->assertSame('success', $delivery->status);
+    }
+}

--- a/tests/Unit/SafeWebhookUrlTest.php
+++ b/tests/Unit/SafeWebhookUrlTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Rules\SafeWebhookUrl;
+use Tests\TestCase;
+
+class SafeWebhookUrlTest extends TestCase
+{
+    public function test_public_ip_literal_url_is_safe(): void
+    {
+        $this->assertTrue(SafeWebhookUrl::isUrlSafe('https://8.8.8.8/webhook'));
+    }
+
+    public function test_loopback_ip_literal_url_is_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://127.0.0.1/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://[::1]/webhook'));
+    }
+
+    public function test_private_range_ip_literal_url_is_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://10.0.0.5/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://172.16.0.5/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://192.168.1.5/webhook'));
+    }
+
+    public function test_link_local_and_cloud_metadata_ip_is_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://169.254.169.254/latest/meta-data/'));
+    }
+
+    public function test_non_http_scheme_is_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('ftp://8.8.8.8/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('file:///etc/passwd'));
+    }
+
+    public function test_unresolvable_hostname_is_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://this-host-should-never-resolve.invalid/webhook'));
+    }
+}


### PR DESCRIPTION
## What was broken

When a user registered an `Endpoint`, the only validation on its `url` was Laravel's generic `url` rule (well-formed URL, any scheme/host). `SendWebhook` then had the application server issue an outbound HTTP POST to that URL with no host/IP restrictions.

Because delivery is fully automated (`POST /api/v1/webhooks/trigger/{eventName}`, no manual approval step), any account on this multi-tenant platform could register an endpoint like `http://169.254.169.254/latest/meta-data/` or an RFC1918 address, then trigger the event to make the server send arbitrary signed POST requests to internal-only infrastructure (cloud metadata services, Redis, Postgres, etc.) — a classic SSRF vulnerability.

## What changed

- Added `App\Rules\SafeWebhookUrl`, a validation rule that resolves an endpoint URL's host and rejects it unless every resolved IP is publicly routable (blocks loopback, link-local/cloud-metadata, private, and other reserved ranges).
- Applied the rule to both `EndpointController::store` and `EndpointController::update`, so unsafe URLs are rejected at creation/edit time with a 422.
- Re-validated the endpoint URL in `SendWebhook::handle()` immediately before dispatch, since DNS can change between endpoint creation and delivery time (DNS rebinding). If a delivery is blocked this way, it's marked `failed` and goes through the normal retry/backoff path.
- Disabled HTTP redirect following (`allow_redirects => false`) on the outbound webhook request, so a public-looking host can't redirect the request to an internal address after validation passes.
- Added unit tests for the new rule and feature tests covering endpoint create/update rejection and the delivery-time check.

Incidentally fixed a stale `ExampleTest` that asserted `GET /` returns 200; the app has redirected `/` to the dashboard route since that route was added, so the test was failing independent of this change and blocking a green test suite.

Fixes #46

---
_Generated by [Claude Code](https://claude.ai/code/session_015cX2gJsEAQgAefKnDSJPg5)_