### PR TITLE
Close SSRF gaps in webhook endpoint validation

### DIFF
--- a/app/Jobs/SendWebhook.php
+++ b/app/Jobs/SendWebhook.php
@@ -48,7 +48,9 @@ class SendWebhook implements ShouldQueue
             return;
         }
 
-        if (! SafeWebhookUrl::isUrlSafe($endpoint->url)) {
+        $safeIp = SafeWebhookUrl::resolveSafeIp($endpoint->url);
+
+        if ($safeIp === null) {
             Log::warning('Webhook delivery blocked: endpoint URL resolves to a disallowed network address', [
                 'delivery_id' => $this->delivery->id,
                 'endpoint_url' => $endpoint->url,
@@ -68,10 +70,24 @@ class SendWebhook implements ShouldQueue
 
         $payload = $this->delivery->payload;
 
+        // Pin the connection to the IP address that was just validated,
+        // rather than letting curl re-resolve the hostname at request time.
+        // Without this, an attacker controlling DNS for the endpoint's
+        // domain could return a safe IP for validation and a private/
+        // internal one moments later for the actual connection.
+        $urlParts = parse_url($endpoint->url);
+        $host = trim($urlParts['host'] ?? '', '[]');
+        $port = $urlParts['port'] ?? (strtolower($urlParts['scheme'] ?? '') === 'https' ? 443 : 80);
+
         try {
             $start = microtime(true);
             $response = Http::timeout(30)
-                ->withOptions(['allow_redirects' => false])
+                ->withOptions([
+                    'allow_redirects' => false,
+                    'curl' => [
+                        CURLOPT_RESOLVE => ["{$host}:{$port}:{$safeIp}"],
+                    ],
+                ])
                 ->withHeaders([
                     'Content-Type' => 'application/json',
                     'X-Webhook-Secret' => hash_hmac('sha256', json_encode($payload), $endpoint->secret_key),

--- a/app/Rules/SafeWebhookUrl.php
+++ b/app/Rules/SafeWebhookUrl.php
@@ -12,6 +12,19 @@ use Illuminate\Contracts\Validation\ValidationRule;
  */
 class SafeWebhookUrl implements ValidationRule
 {
+    /**
+     * IANA special-purpose ranges not excluded by PHP's
+     * FILTER_FLAG_NO_PRIV_RANGE / FILTER_FLAG_NO_RES_RANGE flags.
+     *
+     * @var array<int, string>
+     */
+    private const EXTRA_BLOCKED_RANGES = [
+        '100.64.0.0/10', // RFC 6598 shared address space (CGNAT)
+        '192.0.0.0/24',  // IETF protocol assignments
+        '192.0.2.0/24',  // TEST-NET-1
+        '198.18.0.0/15', // benchmarking
+    ];
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! is_string($value) || ! self::isUrlSafe($value)) {
@@ -25,15 +38,7 @@ class SafeWebhookUrl implements ValidationRule
      */
     public static function isUrlSafe(string $url): bool
     {
-        $parts = parse_url($url);
-        $scheme = strtolower($parts['scheme'] ?? '');
-        $host = $parts['host'] ?? null;
-
-        if (! in_array($scheme, ['http', 'https'], true) || ! $host) {
-            return false;
-        }
-
-        return self::isHostSafe($host);
+        return self::resolveSafeIp($url) !== null;
     }
 
     /**
@@ -42,20 +47,90 @@ class SafeWebhookUrl implements ValidationRule
      */
     public static function isHostSafe(string $host): bool
     {
+        return self::resolveSafeHostIp($host) !== null;
+    }
+
+    /**
+     * Resolve a webhook URL's host to a single validated, publicly routable
+     * IP address, or null if the URL is unsafe/unresolvable.
+     *
+     * Callers making the actual outbound request should connect directly to
+     * this IP (e.g. via curl's CURLOPT_RESOLVE) rather than letting the HTTP
+     * client re-resolve the hostname, to avoid a DNS-rebinding race between
+     * validation and the request itself.
+     */
+    public static function resolveSafeIp(string $url): ?string
+    {
+        $parts = parse_url($url);
+        $scheme = strtolower($parts['scheme'] ?? '');
+        $host = $parts['host'] ?? null;
+
+        if (! in_array($scheme, ['http', 'https'], true) || ! $host) {
+            return null;
+        }
+
+        return self::resolveSafeHostIp($host);
+    }
+
+    private static function resolveSafeHostIp(string $host): ?string
+    {
         $host = trim($host, '[]');
         $ips = filter_var($host, FILTER_VALIDATE_IP) ? [$host] : self::resolveHost($host);
 
         if (empty($ips)) {
-            return false;
+            return null;
         }
 
         foreach ($ips as $ip) {
-            if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            if (! self::isIpSafe($ip)) {
+                return null;
+            }
+        }
+
+        return $ips[0];
+    }
+
+    private static function isIpSafe(string $ip): bool
+    {
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false) {
+            return false;
+        }
+
+        foreach (self::EXTRA_BLOCKED_RANGES as $range) {
+            if (self::ipInRange($ip, $range)) {
                 return false;
             }
         }
 
         return true;
+    }
+
+    private static function ipInRange(string $ip, string $cidr): bool
+    {
+        [$subnet, $bits] = explode('/', $cidr);
+
+        $ipBin = inet_pton($ip);
+        $subnetBin = inet_pton($subnet);
+
+        if ($ipBin === false || $subnetBin === false || strlen($ipBin) !== strlen($subnetBin)) {
+            return false;
+        }
+
+        $bits = (int) $bits;
+        $bytes = intdiv($bits, 8);
+        $remainderBits = $bits % 8;
+
+        if ($bytes > 0 && substr($ipBin, 0, $bytes) !== substr($subnetBin, 0, $bytes)) {
+            return false;
+        }
+
+        if ($remainderBits === 0) {
+            return true;
+        }
+
+        $mask = chr((0xFF << (8 - $remainderBits)) & 0xFF);
+
+        return (substr($ipBin, $bytes, 1) & $mask) === (substr($subnetBin, $bytes, 1) & $mask);
     }
 
     /**

--- a/tests/Feature/SendWebhookSsrfProtectionTest.php
+++ b/tests/Feature/SendWebhookSsrfProtectionTest.php
@@ -69,4 +69,34 @@ class SendWebhookSsrfProtectionTest extends TestCase
         $delivery->refresh();
         $this->assertSame('success', $delivery->status);
     }
+
+    public function test_delivery_to_cgnat_address_is_blocked_without_making_a_request(): void
+    {
+        Http::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $event = Event::factory()->for($user)->create();
+
+        // Bypasses controller validation, same as the metadata-IP test above,
+        // to simulate a URL that resolves into the RFC 6598 CGNAT range.
+        $endpoint = Endpoint::factory()->for($user)->create([
+            'url' => 'http://100.64.0.1/webhook',
+        ]);
+
+        $delivery = Delivery::factory()->create([
+            'event_id' => $event->id,
+            'endpoint_id' => $endpoint->id,
+            'status' => 'pending',
+            'attempt_count' => 0,
+            'next_retry_at' => null,
+        ]);
+
+        (new SendWebhook($delivery))->handle();
+
+        Http::assertNothingSent();
+
+        $delivery->refresh();
+        $this->assertSame('failed', $delivery->status);
+        $this->assertStringContainsString('blocked', strtolower($delivery->response_body));
+    }
 }

--- a/tests/Unit/SafeWebhookUrlTest.php
+++ b/tests/Unit/SafeWebhookUrlTest.php
@@ -40,4 +40,34 @@ class SafeWebhookUrlTest extends TestCase
     {
         $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://this-host-should-never-resolve.invalid/webhook'));
     }
+
+    public function test_cgnat_shared_address_space_is_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://100.64.0.1/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://100.100.100.100/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://100.127.255.254/webhook'));
+    }
+
+    public function test_addresses_adjacent_to_cgnat_range_are_still_safe(): void
+    {
+        $this->assertTrue(SafeWebhookUrl::isUrlSafe('http://100.63.255.255/webhook'));
+        $this->assertTrue(SafeWebhookUrl::isUrlSafe('http://100.128.0.0/webhook'));
+    }
+
+    public function test_other_iana_special_purpose_ranges_are_unsafe(): void
+    {
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://192.0.0.5/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://192.0.2.5/webhook'));
+        $this->assertFalse(SafeWebhookUrl::isUrlSafe('http://198.18.5.5/webhook'));
+    }
+
+    public function test_resolve_safe_ip_returns_the_ip_for_a_safe_url(): void
+    {
+        $this->assertSame('8.8.8.8', SafeWebhookUrl::resolveSafeIp('https://8.8.8.8/webhook'));
+    }
+
+    public function test_resolve_safe_ip_returns_null_for_an_unsafe_url(): void
+    {
+        $this->assertNull(SafeWebhookUrl::resolveSafeIp('http://100.64.0.1/webhook'));
+    }
 }


### PR DESCRIPTION
## What was broken

`SafeWebhookUrl` (added in #48 to prevent SSRF via webhook endpoint URLs) has two gaps:

1. **CGNAT range not blocked** — PHP's `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE` flags do not exclude `100.64.0.0/10` (RFC 6598 shared/carrier-grade NAT address space), nor a few other IANA special-purpose ranges (`192.0.0.0/24`, `192.0.2.0/24`, `198.18.0.0/15`). A webhook endpoint URL resolving into these ranges passed both the create/update validator and the pre-send check in `SendWebhook::handle()`.
2. **DNS re-resolution TOCTOU** — the host was resolved once via `dns_get_record()` for validation, and then resolved *again* independently by curl when the actual outbound request was made a few lines later. An attacker controlling DNS for the endpoint's domain could return a public IP for the validation lookup and a private/internal address (e.g. a cloud metadata endpoint) for the connection lookup moments later, bypassing the SSRF guard entirely.

## What changed

- `SafeWebhookUrl` now checks every resolved IP against the additional blocked ranges via an explicit CIDR check, alongside the existing `FILTER_VALIDATE_IP` flags.
- Added `SafeWebhookUrl::resolveSafeIp()`, which resolves a URL's host once and returns the single validated IP address to connect to.
- `SendWebhook::handle()` now uses `resolveSafeIp()` and pins the outbound request to that exact IP via curl's `CURLOPT_RESOLVE`, instead of letting curl re-resolve the hostname independently at request time. This closes the DNS-rebinding window between validation and the actual connection.

## Tests

- Added unit tests in `SafeWebhookUrlTest` covering the CGNAT range, the other newly-blocked IANA ranges, and boundary addresses just outside those ranges.
- Added a feature test in `SendWebhookSsrfProtectionTest` confirming a delivery to a CGNAT-range endpoint is blocked without making a request.
- Full test suite passes (`php artisan test`).

Fixes #52


---
_Generated by [Claude Code](https://claude.ai/code/session_01ABzpzAGLeuCZKqzRTgTeYm)_