### PR TITLE
Close SSRF gap in web dashboard endpoint controller

### DIFF
--- a/app/Http/Controllers/EndpointController.php
+++ b/app/Http/Controllers/EndpointController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Endpoint;
+use App\Rules\SafeWebhookUrl;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -16,7 +17,7 @@ class EndpointController extends Controller
     {
         $validated = $request->validate([
             'name' => 'required|string|max:255',
-            'url' => 'required|url|max:2048',
+            'url' => ['required', 'url', 'max:2048', new SafeWebhookUrl],
             'description' => 'nullable|string|max:1000',
             'is_active' => 'boolean',
         ]);
@@ -35,7 +36,7 @@ class EndpointController extends Controller
 
         $validated = $request->validate([
             'name' => 'sometimes|string|max:255',
-            'url' => 'sometimes|url|max:2048',
+            'url' => ['sometimes', 'url', 'max:2048', new SafeWebhookUrl],
             'description' => 'nullable|string|max:1000',
             'is_active' => 'boolean',
         ]);
@@ -58,20 +59,44 @@ class EndpointController extends Controller
     {
         abort_if($endpoint->user_id !== $request->user()->id, 403);
 
-        try {
-            $response = Http::timeout(10)->post($endpoint->url, ['test' => true]);
+        $safeIp = SafeWebhookUrl::resolveSafeIp($endpoint->url);
 
-            $testResult = [
-                'success' => $response->successful(),
-                'response_code' => $response->status(),
-                'message' => $response->body(),
-            ];
-        } catch (\Exception $e) {
+        if ($safeIp === null) {
             $testResult = [
                 'success' => false,
                 'response_code' => null,
-                'message' => $e->getMessage(),
+                'message' => 'Blocked: endpoint URL resolves to a private, loopback, or reserved network address.',
             ];
+        } else {
+            // Pin the connection to the IP address that was just validated,
+            // rather than letting curl re-resolve the hostname at request time,
+            // to avoid a DNS-rebinding race between validation and the request.
+            $urlParts = parse_url($endpoint->url);
+            $host = trim($urlParts['host'] ?? '', '[]');
+            $port = $urlParts['port'] ?? (strtolower($urlParts['scheme'] ?? '') === 'https' ? 443 : 80);
+
+            try {
+                $response = Http::timeout(10)
+                    ->withOptions([
+                        'allow_redirects' => false,
+                        'curl' => [
+                            CURLOPT_RESOLVE => ["{$host}:{$port}:{$safeIp}"],
+                        ],
+                    ])
+                    ->post($endpoint->url, ['test' => true]);
+
+                $testResult = [
+                    'success' => $response->successful(),
+                    'response_code' => $response->status(),
+                    'message' => $response->body(),
+                ];
+            } catch (\Exception $e) {
+                $testResult = [
+                    'success' => false,
+                    'response_code' => null,
+                    'message' => $e->getMessage(),
+                ];
+            }
         }
 
         $endpoints = $request->user()->endpoints()->with('events')->paginate(15);

--- a/tests/Feature/WebEndpointSsrfProtectionTest.php
+++ b/tests/Feature/WebEndpointSsrfProtectionTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Endpoint;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class WebEndpointSsrfProtectionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_endpoint_via_dashboard_with_loopback_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->post('/endpoints', [
+            'name' => 'Malicious Endpoint',
+            'url' => 'http://127.0.0.1/steal-data',
+        ]);
+
+        $response->assertSessionHasErrors('url');
+        $this->assertDatabaseCount('endpoints', 0);
+    }
+
+    public function test_creating_endpoint_via_dashboard_with_cloud_metadata_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+
+        $response = $this->actingAs($user)->post('/endpoints', [
+            'name' => 'Metadata Endpoint',
+            'url' => 'http://169.254.169.254/latest/meta-data/',
+        ]);
+
+        $response->assertSessionHasErrors('url');
+        $this->assertDatabaseCount('endpoints', 0);
+    }
+
+    public function test_updating_endpoint_via_dashboard_to_private_network_url_is_rejected(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $endpoint = Endpoint::factory()->for($user)->create();
+
+        $response = $this->actingAs($user)->put("/endpoints/{$endpoint->id}", [
+            'url' => 'http://10.0.0.5/internal-api',
+        ]);
+
+        $response->assertSessionHasErrors('url');
+        $this->assertDatabaseHas('endpoints', ['id' => $endpoint->id, 'url' => $endpoint->url]);
+    }
+
+    public function test_test_webhook_action_is_blocked_for_endpoint_pointing_at_metadata_service(): void
+    {
+        Http::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+
+        // Bypasses controller validation to simulate a DNS-rebinding scenario
+        // where the endpoint URL resolved safely at creation time but not now.
+        $endpoint = Endpoint::factory()->for($user)->create([
+            'url' => 'http://169.254.169.254/latest/meta-data/',
+        ]);
+
+        $response = $this->actingAs($user)->post("/endpoints/{$endpoint->id}/test");
+
+        Http::assertNothingSent();
+        $response->assertInertia(fn ($page) => $page
+            ->where('testResult.success', false)
+            ->where('testResult.response_code', null)
+        );
+    }
+
+    public function test_test_webhook_action_makes_a_request_for_a_safe_url(): void
+    {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $endpoint = Endpoint::factory()->for($user)->create(['url' => 'http://8.8.8.8/webhook']);
+
+        $response = $this->actingAs($user)->post("/endpoints/{$endpoint->id}/test");
+
+        Http::assertSent(fn ($request) => $request->url() === 'http://8.8.8.8/webhook');
+        $response->assertInertia(fn ($page) => $page
+            ->where('testResult.success', true)
+            ->where('testResult.response_code', 200)
+        );
+    }
+}


### PR DESCRIPTION
## What was broken

PRs #48/#59 hardened SSRF validation for webhook endpoint URLs, but only in `App\Http\Controllers\Api\EndpointController` and `App\Jobs\SendWebhook`. The parallel web-dashboard controller (`App\Http\Controllers\EndpointController`, wired in `routes/web.php`) manages the exact same `Endpoint` resource but had no SSRF protection at all:

- `store()` and `update()` validated `url` as `required|url|max:2048` / `sometimes|url|max:2048` only — no `SafeWebhookUrl` rule — so any logged-in user could create or repoint an endpoint at `169.254.169.254` (cloud metadata), `127.0.0.1`, an internal `10.x` address, etc. directly through the dashboard.
- `test()` made a live, synchronous, unauthenticated-to-the-target request (`Http::timeout(10)->post($endpoint->url, ...)`) with no IP validation, no `allow_redirects => false`, and no `CURLOPT_RESOLVE` IP pinning, then reflected the raw response body straight back to the browser (`'message' => $response->body()`).

Combined, this was a complete, immediately-exploitable SSRF with data exfiltration: an authenticated user could point an endpoint at an internal service and use "Test Webhook" to have the server fetch it and echo the response back into the UI.

## What changed

- `store()` / `update()` in `app/Http/Controllers/EndpointController.php` now validate `url` with the existing `App\Rules\SafeWebhookUrl` rule, matching the API controller.
- `test()` now resolves and validates the endpoint URL via `SafeWebhookUrl::resolveSafeIp()` before making any request, and pins the outbound connection to that validated IP via `CURLOPT_RESOLVE` with `allow_redirects => false` disabled, mirroring the protections already used in `app/Jobs/SendWebhook.php`. URLs that fail validation are blocked with no outbound request made.
- Added `tests/Feature/WebEndpointSsrfProtectionTest.php` covering: rejecting loopback/metadata URLs on create, rejecting private-network URLs on update, blocking the "Test Webhook" action for an endpoint pointing at the metadata service (no request sent), and confirming the action still works for a safe URL.

Fixes #62