### PR TITLE
Require auth on deprecated unversioned webhook trigger route

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -71,6 +71,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('deliveries/{delivery}', [DeliveryController::class, 'show']);
 
     Route::post('deliveries/{delivery}/retry', [WebhookController::class, 'retryDelivery']);
+
+    Route::post('webhooks/trigger/{eventName}', [WebhookController::class, 'trigger'])
+        ->middleware('throttle:webhook-trigger');
 });
-Route::post('webhooks/trigger/{eventName}', [WebhookController::class, 'trigger'])
-    ->middleware('throttle:webhook-trigger');

--- a/tests/Feature/DeprecatedWebhookTriggerAuthTest.php
+++ b/tests/Feature/DeprecatedWebhookTriggerAuthTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Endpoint;
+use App\Models\Event;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class DeprecatedWebhookTriggerAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deprecated_trigger_route_rejects_unauthenticated_requests(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $event = Event::factory()->for($user)->create(['name' => 'order.created']);
+
+        $response = $this->postJson('/api/webhooks/trigger/'.$event->name, [
+            'payload' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_deprecated_trigger_route_works_for_authenticated_users(): void
+    {
+        Http::fake();
+
+        $user = User::factory()->withPersonalTeam()->create();
+        $event = Event::factory()->for($user)->create(['name' => 'order.created']);
+        $endpoint = Endpoint::factory()->for($user)->create(['is_active' => true]);
+        $event->endpoints()->attach($endpoint);
+
+        $response = $this->actingAs($user)->postJson('/api/webhooks/trigger/'.$event->name, [
+            'payload' => ['foo' => 'bar'],
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['event' => $event->name, 'deliveries_created' => 1]);
+    }
+}


### PR DESCRIPTION
## What was broken

The deprecated, unversioned `POST /api/webhooks/trigger/{eventName}` route (`routes/api.php`) was declared *outside* the `auth:sanctum` middleware group that wraps every other unversioned API route, so it ran with no authentication middleware at all.

`WebhookController::trigger()` relies entirely on route middleware to guarantee `$request->user()` is non-null — it calls `$request->user()->id` with no auth check of its own. Today this happens not to leak data (an unauthenticated request resolves `user()->id` to `null`, so the `Event` lookup effectively becomes `whereNull('user_id')` against a `NOT NULL` column and always 404s), but that's incidental behavior, not an explicit guard. The route was still reachable by completely unauthenticated clients, throttled only by IP, and any future change to how the user ID is resolved could turn this into a genuine unauthenticated webhook-trigger vector. It was also inconsistent with every other route, including this route's own v1 equivalent, which is correctly wrapped in `auth:sanctum`.

## What changed

- Moved the deprecated `webhooks/trigger/{eventName}` route inside the existing `Route::middleware('auth:sanctum')->group(...)` block in `routes/api.php`, alongside its sibling deprecated aliases, matching how the canonical v1 route is grouped. The route keeps its `throttle:webhook-trigger` middleware.
- Added `tests/Feature/DeprecatedWebhookTriggerAuthTest.php` covering:
  - An unauthenticated request to the deprecated route is rejected with `401`.
  - An authenticated request still triggers the event and creates deliveries as before.

## Testing

- `vendor/bin/pint --dirty` — clean
- `composer test` (full suite) — passes (57 passed, 7 pre-existing skips unrelated to this change)

Fixes #50

---
_Generated by [Claude Code](https://claude.ai/code/session_017yfhphMFQH2PMyBoMA7F6a)_