### PR TITLE
Require authentication for Postgres and Redis in docker-compose

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -214,7 +214,7 @@ All services communicate through the `webhook-network` bridge network:
 
 - Services can communicate using service names (e.g., `app`, `db`, `redis`)
 - External access is provided through Nginx on port 80/443
-- Database and Redis are accessible on standard ports for debugging
+- Database and Redis are not published to the host in the base `docker-compose.yml`; `docker-compose.override.yml` (development only) publishes them on their standard ports for local debugging
 
 ## Resource Management
 
@@ -238,7 +238,7 @@ All services communicate through the `webhook-network` bridge network:
 ### Environment Variables
 - The main `.env` file is copied into containers during build
 - Secrets should be managed through the `.env` file
-- Database passwords should be changed in production
+- Database and Redis passwords should be changed in production
 - SSL certificates should be mounted for HTTPS
 - APP_KEY is required and must be generated before building containers
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,13 @@
 services:
   # Development overrides
+  db:
+    ports:
+      - "5432:5432"
+
+  redis:
+    ports:
+      - "6379:6379"
+
   app:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,12 +8,9 @@ services:
       POSTGRES_DB: webhook_management
       POSTGRES_USER: webhook_user
       POSTGRES_PASSWORD: webhook_password
-      POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./docker/init.sql:/docker-entrypoint-initdb.d/init.sql
-    ports:
-      - "5432:5432"
     networks:
       - webhook-network
 
@@ -22,11 +19,9 @@ services:
     image: redis:7-alpine
     container_name: webhook_redis
     restart: unless-stopped
-    command: redis-server --appendonly yes
+    command: redis-server --appendonly yes --requirepass webhook_redis_password
     volumes:
       - redis_data:/data
-    ports:
-      - "6379:6379"
     networks:
       - webhook-network
 
@@ -51,6 +46,7 @@ services:
       - DB_PASSWORD=webhook_password
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=webhook_redis_password
       - QUEUE_CONNECTION=redis
       - CACHE_DRIVER=redis
       - SESSION_DRIVER=redis
@@ -81,6 +77,7 @@ services:
       - DB_PASSWORD=webhook_password
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=webhook_redis_password
       - QUEUE_CONNECTION=redis
     volumes:
       - storage_data:/var/www/html/storage
@@ -109,6 +106,7 @@ services:
       - DB_PASSWORD=webhook_password
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=webhook_redis_password
       - QUEUE_CONNECTION=redis
     volumes:
       - storage_data:/var/www/html/storage


### PR DESCRIPTION
## What was broken

The base `docker-compose.yml` published Postgres and Redis directly to the host network with effectively no authentication:

- `db` service set `POSTGRES_HOST_AUTH_METHOD: trust`, which makes Postgres accept *any* connection without checking a password — so `POSTGRES_PASSWORD` was decorative for any client that could reach the port. Combined with `ports: "5432:5432"`, anyone with network access to the Docker host (not just other containers on `webhook-network`) could connect as `webhook_user` and get full read/write access to the database, including hashed user passwords and webhook signing secrets.
- `redis` service ran with no `--requirepass` and published `6379:6379` to the host, giving unauthenticated access to queued webhook delivery jobs and cache/session data.
- This directly contradicted `DOCKER.md`'s documented "Network Security" section, which claimed the database and Redis are not directly accessible from outside the Docker network.

## What changed

- Removed `POSTGRES_HOST_AUTH_METHOD: trust` from `docker-compose.yml` so Postgres enforces its configured `POSTGRES_PASSWORD` via its default password auth.
- Added `--requirepass` to the Redis `command` and wired the matching `REDIS_PASSWORD` into the `app`, `queue`, and `scheduler` service environments (the app config already read `REDIS_PASSWORD` from the environment, so no PHP changes were needed).
- Removed the host `ports:` mappings for `db` and `redis` from the base `docker-compose.yml` — these services only need to be reachable from `app`/`queue`/`scheduler` over the internal `webhook-network`.
- Moved host port publishing for `db` (`5432:5432`) and `redis` (`6379:6379`) into `docker-compose.override.yml`, the development-only overlay, so local debugging access still works out of the box via `make up`/`make dev` without exposing these services in a production deployment that uses the base file alone.
- Updated `DOCKER.md` to accurately describe the new network posture.

Verified the merged compose config with `docker compose config` for both the base file alone and base+override, confirming the base file publishes no `db`/`redis` ports and enforces auth, while the override still exposes them for local development.

No PHP code changed, so no new PHPUnit tests were needed; the full existing test suite (`composer test`) passes (57 passed, 7 pre-existing skips).

Fixes #72

---
_Generated by [Claude Code](https://claude.ai/code/session_01WhxAmXLkDYzhjVNFtKf2Gp)_